### PR TITLE
Correction du titre

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 :warning: Travail en cours de mise au point d'un schéma pour le schéma de comptage vélo.
 
-# Schéma de données pour le stationnement cyclable
+# Schéma de données pour le comptage vélo, partie statique
 
 Schéma de comptage vélo statique
 


### PR DESCRIPTION
Correction du titre : "# Schéma de données pour le stationnement vélo" à "# Schéma de données pour le comptage vélo, partie statique"